### PR TITLE
wip: absolute references for the shared / reusable workflows

### DIFF
--- a/.github/workflows/auto-tag-release-push.yml
+++ b/.github/workflows/auto-tag-release-push.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   tag:
-    uses: ./.github/workflows/auto-tag-release.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/gitleaks-check.yml
+++ b/.github/workflows/gitleaks-check.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-tags: true
 
       - name: Gitleaks scan
-        uses: ./.github/actions/gitleaks-scan
+        uses: nikolareljin/ci-helpers/.github/actions/gitleaks-scan@production
         with:
           scan_path: "."
           report_format: sarif

--- a/.github/workflows/gitleaks-scan.yml
+++ b/.github/workflows/gitleaks-scan.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Gitleaks scan
-        uses: ./.github/actions/gitleaks-scan
+        uses: nikolareljin/ci-helpers/.github/actions/gitleaks-scan@production
         with:
           scan_path: ${{ inputs.scan_path }}
           report_format: ${{ inputs.report_format }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/java-gradle.yml
+++ b/.github/workflows/java-gradle.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check release tag availability
         if: ${{ inputs.check_release_tag }}
-        uses: ./.github/actions/check-release-tag
+        uses: nikolareljin/ci-helpers/.github/actions/check-release-tag@production
         with:
           release_branch: ${{ inputs.release_branch }}
           repo_dir: ${{ github.workspace }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/release-tag-check.yml
+++ b/.github/workflows/release-tag-check.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-tags: true
 
       - name: Check release tag availability
-        uses: ./.github/actions/check-release-tag
+        uses: nikolareljin/ci-helpers/.github/actions/check-release-tag@production
         with:
           release_branch: ${{ github.ref_name }}
           repo_dir: ${{ github.workspace }}

--- a/.github/workflows/release-tag-gate.yml
+++ b/.github/workflows/release-tag-gate.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Check release tag availability
         if: ${{ steps.gate.outputs.run_check == 'true' }}
-        uses: ./.github/actions/check-release-tag
+        uses: nikolareljin/ci-helpers/.github/actions/check-release-tag@production
         with:
           release_branch: ${{ steps.branches.outputs.release_branch }}
           repo_dir: ${{ github.workspace }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Trivy scan
-        uses: ./.github/actions/trivy-scan
+        uses: nikolareljin/ci-helpers/.github/actions/trivy-scan@production
         with:
           scan_path: ${{ inputs.scan_path }}
           format: ${{ inputs.format }}

--- a/.github/workflows/wp-plugin-check.yml
+++ b/.github/workflows/wp-plugin-check.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: WordPress plugin check
-        uses: ./.github/actions/wp-plugin-check
+        uses: nikolareljin/ci-helpers/.github/actions/wp-plugin-check@production
         with:
           compose_file: ${{ inputs.compose_file }}
           plugin_slug: ${{ inputs.plugin_slug }}


### PR DESCRIPTION
This pull request updates several GitHub Actions and workflow files to reference reusable workflows and actions from the external `nikolareljin/ci-helpers` repository instead of local copies. This change centralizes CI/CD logic, making maintenance easier and ensuring consistency across workflows.