### PR TITLE
fix: harden auto-tag release detection

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -41,7 +41,7 @@ jobs:
             const payloadDefault = context.payload?.repository?.default_branch || '';
             const defaultBranch = inputDefault || payloadDefault || 'main';
             const releaseHeadPattern = /^release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/;
-            const mergeMessagePattern = /^Merge pull request #\d+ from (?:.+\/)?release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/m;
+            const mergeMessagePattern = /^Merge pull request #(\d+) from (?:.+\/)?release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/;
 
             if (refName !== defaultBranch) {
               core.info(`Push landed on ${refName}; default branch is ${defaultBranch}. Skipping.`);
@@ -50,33 +50,66 @@ jobs:
             }
 
             let version = '';
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-            });
+            try {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
 
-            const merged = prs.data.find(
-              (pr) =>
-                pr.merged_at &&
-                pr.base.ref === defaultBranch &&
-                pr.merge_commit_sha === sha
-            );
-            if (merged) {
-              const match = String(merged.head.ref || '').match(releaseHeadPattern);
-              if (match) {
-                version = match[1];
-                core.info(`Resolved release version ${version} from PR #${merged.number}.`);
+              const merged = prs.data.find(
+                (pr) =>
+                  pr.merged_at &&
+                  pr.base.ref === defaultBranch &&
+                  pr.merge_commit_sha === sha
+              );
+              if (merged) {
+                const match = String(merged.head.ref || '').match(releaseHeadPattern);
+                if (match) {
+                  version = match[1];
+                  core.info(`Resolved release version ${version} from PR #${merged.number}.`);
+                }
               }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              core.warning(
+                `Unable to list pull requests associated with ${sha}; continuing to merge-subject fallback. ` +
+                `Caller workflows should grant pull-requests: read. Details: ${message}`
+              );
             }
 
             if (!version) {
               const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
               const message = String(commit.data.commit.message || '');
-              const match = message.match(mergeMessagePattern);
+              const subject = message.split(/\r?\n/, 1)[0] || '';
+              const match = subject.match(mergeMessagePattern);
               if (match) {
-                version = match[1];
-                core.info(`Resolved release version ${version} from merge commit message fallback.`);
+                const prNumber = Number(match[1]);
+                const fallbackVersion = match[2];
+                try {
+                  const pr = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: prNumber,
+                  });
+                  const prData = pr.data;
+                  const headMatch = String(prData.head?.ref || '').match(releaseHeadPattern);
+                  if (
+                    prData.merged_at &&
+                    prData.base?.ref === defaultBranch &&
+                    prData.merge_commit_sha === sha &&
+                    headMatch &&
+                    headMatch[1] === fallbackVersion
+                  ) {
+                    version = fallbackVersion;
+                    core.info(`Resolved release version ${version} from validated merge commit message fallback for PR #${prNumber}.`);
+                  } else {
+                    core.warning(`Merge commit message referenced PR #${prNumber}, but it did not validate against ${sha}.`);
+                  }
+                } catch (error) {
+                  const detail = error instanceof Error ? error.message : String(error);
+                  core.warning(`Merge commit message referenced PR #${prNumber}, but the PR could not be validated: ${detail}`);
+                }
               }
             }
 

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   tag:
@@ -24,24 +25,27 @@ jobs:
           fetch-depth: ${{ inputs.fetch_depth }}
           fetch-tags: true
 
-      - name: Resolve default branch
-        id: defaults
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const input = core.getInput("default_branch");
-            const payloadDefault = context.payload?.repository?.default_branch || "";
-            const branch = input || payloadDefault || "main";
-            core.setOutput("default_branch", branch);
-
       - name: Detect release version
         id: release
         uses: actions/github-script@v7
         with:
           script: |
             const sha = context.sha;
+            const refName = context.ref.replace('refs/heads/', '');
             const { owner, repo } = context.repo;
-            const defaultBranch = "${{ steps.defaults.outputs.default_branch }}";
+            const inputDefault = core.getInput('default_branch');
+            const payloadDefault = context.payload?.repository?.default_branch || '';
+            const defaultBranch = inputDefault || payloadDefault || 'main';
+            const releaseHeadPattern = /^release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/;
+            const mergeMessagePattern = /^Merge pull request #\d+ from (?:.+\/)?release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/m;
+
+            if (refName !== defaultBranch) {
+              core.info(`Push landed on ${refName}; default branch is ${defaultBranch}. Skipping.`);
+              core.setOutput('version', '');
+              return;
+            }
+
+            let version = '';
             const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner,
               repo,
@@ -49,22 +53,34 @@ jobs:
             });
 
             const merged = prs.data.find(
-              (pr) => pr.merged_at && pr.base.ref === defaultBranch
+              (pr) =>
+                pr.merged_at &&
+                pr.base.ref === defaultBranch &&
+                pr.merge_commit_sha === sha
             );
-            if (!merged) {
-              core.info("No merged PR associated with the latest commit.");
-              core.setOutput("version", "");
-              return;
+            if (merged) {
+              const match = String(merged.head.ref || '').match(releaseHeadPattern);
+              if (match) {
+                version = match[1];
+                core.info(`Resolved release version ${version} from PR #${merged.number}.`);
+              }
             }
 
-            const match = merged.head.ref.match(/^release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/);
-            if (!match) {
-              core.info("Merged PR is not a release/* branch.");
-              core.setOutput("version", "");
-              return;
+            if (!version) {
+              const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+              const message = String(commit.data.commit.message || '');
+              const match = message.match(mergeMessagePattern);
+              if (match) {
+                version = match[1];
+                core.info(`Resolved release version ${version} from merge commit message fallback.`);
+              }
             }
 
-            core.setOutput("version", match[1]);
+            if (!version) {
+              core.info('No release/* merge detected for this push.');
+            }
+
+            core.setOutput('version', version);
 
       - name: Check tag availability
         if: ${{ steps.release.outputs.version != '' }}

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -73,8 +73,9 @@ jobs:
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error);
               core.warning(
-                `Unable to list pull requests associated with ${sha}; continuing to merge-subject fallback. ` +
-                `Caller workflows should grant pull-requests: read. Details: ${message}`
+                `Unable to list pull requests associated with ${sha}. Falling back to merge-commit subject parsing, ` +
+                `but final PR-based validation in this workflow also requires pull-requests: read; without it, tagging may be skipped. ` +
+                `Details: ${message}`
               );
             }
 

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: write
+  # NOTE: Caller workflows must also grant `pull-requests: read`; reusable
+  # workflows cannot elevate the GITHUB_TOKEN permissions of their callers.
   pull-requests: read
 
 jobs:
@@ -28,12 +30,14 @@ jobs:
       - name: Detect release version
         id: release
         uses: actions/github-script@v7
+        env:
+          INPUT_DEFAULT_BRANCH: ${{ inputs.default_branch }}
         with:
           script: |
             const sha = context.sha;
             const refName = context.ref.replace('refs/heads/', '');
             const { owner, repo } = context.repo;
-            const inputDefault = core.getInput('default_branch');
+            const inputDefault = process.env.INPUT_DEFAULT_BRANCH || '';
             const payloadDefault = context.payload?.repository?.default_branch || '';
             const defaultBranch = inputDefault || payloadDefault || 'main';
             const releaseHeadPattern = /^release\/v?(\d+\.\d+\.\d+(?:-rc\.?\d+)?)$/;

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -74,43 +74,51 @@ jobs:
               const message = error instanceof Error ? error.message : String(error);
               core.warning(
                 `Unable to list pull requests associated with ${sha}. Falling back to merge-commit subject parsing, ` +
-                `but final PR-based validation in this workflow also requires pull-requests: read; without it, tagging may be skipped. ` +
+                `but final PR-based validation in this workflow also requires pull-requests: read; without it, tagging will be skipped. ` +
                 `Details: ${message}`
               );
             }
 
             if (!version) {
-              const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
-              const message = String(commit.data.commit.message || '');
-              const subject = message.split(/\r?\n/, 1)[0] || '';
-              const match = subject.match(mergeMessagePattern);
-              if (match) {
-                const prNumber = Number(match[1]);
-                const fallbackVersion = match[2];
-                try {
-                  const pr = await github.rest.pulls.get({
-                    owner,
-                    repo,
-                    pull_number: prNumber,
-                  });
-                  const prData = pr.data;
-                  const headMatch = String(prData.head?.ref || '').match(releaseHeadPattern);
-                  if (
-                    prData.merged_at &&
-                    prData.base?.ref === defaultBranch &&
-                    prData.merge_commit_sha === sha &&
-                    headMatch &&
-                    headMatch[1] === fallbackVersion
-                  ) {
-                    version = fallbackVersion;
-                    core.info(`Resolved release version ${version} from validated merge commit message fallback for PR #${prNumber}.`);
-                  } else {
-                    core.warning(`Merge commit message referenced PR #${prNumber}, but it did not validate against ${sha}.`);
+              try {
+                const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+                const message = String(commit.data.commit.message || '');
+                const subject = message.split(/\r?\n/, 1)[0] || '';
+                const match = subject.match(mergeMessagePattern);
+                if (match) {
+                  const prNumber = Number(match[1]);
+                  const fallbackVersion = match[2];
+                  try {
+                    const pr = await github.rest.pulls.get({
+                      owner,
+                      repo,
+                      pull_number: prNumber,
+                    });
+                    const prData = pr.data;
+                    const headMatch = String(prData.head?.ref || '').match(releaseHeadPattern);
+                    if (
+                      prData.merged_at &&
+                      prData.base?.ref === defaultBranch &&
+                      prData.merge_commit_sha === sha &&
+                      headMatch &&
+                      headMatch[1] === fallbackVersion
+                    ) {
+                      version = fallbackVersion;
+                      core.info(`Resolved release version ${version} from validated merge commit message fallback for PR #${prNumber}.`);
+                    } else {
+                      core.warning(`Merge commit message referenced PR #${prNumber}, but it did not validate against ${sha}.`);
+                    }
+                  } catch (error) {
+                    const detail = error instanceof Error ? error.message : String(error);
+                    core.warning(`Merge commit message referenced PR #${prNumber}, but the PR could not be validated: ${detail}`);
                   }
-                } catch (error) {
-                  const detail = error instanceof Error ? error.message : String(error);
-                  core.warning(`Merge commit message referenced PR #${prNumber}, but the PR could not be validated: ${detail}`);
                 }
+              } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
+                core.info(
+                  `Unable to fetch commit ${sha} or parse its message for release tagging fallback. ` +
+                  `Skipping merge-commit subject based version resolution. Details: ${detail}`
+                );
               }
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-24
+
+### Fixed
+- Hardened `auto-tag-release.yml` so merged release branches still tag correctly when GitHub has not yet associated the merge commit with its PR, using a merge-commit-message fallback plus default-branch and `merge_commit_sha` guards.
+
 ## 2026-03-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-03-24
 
 ### Fixed
-- Hardened `auto-tag-release.yml` so merged release branches still tag correctly when GitHub has not yet associated the merge commit with its PR, using a merge-commit-message fallback plus default-branch and `merge_commit_sha` guards.
+- Hardened `auto-tag-release.yml` so merged release branches still tag correctly when GitHub has not yet associated the merge commit with its PR, using a merge-subject fallback that validates the referenced PR plus default-branch and `merge_commit_sha` guards.
 
 ## 2026-03-20
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -260,6 +260,10 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -369,6 +369,10 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
@@ -625,6 +629,10 @@ name: Auto Tag Release
 on:
   push:
     branches: [ main, master ]
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   tag:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -718,7 +718,9 @@ Purpose: Auto-tag releases when a `release/X.Y.Z` or `release/X.Y.Z-rcN` PR is m
 Notes:
 - Detects the repo default branch; falls back to `main` if missing.
 - Only tags pushes that land on the actual default branch.
-- Falls back to parsing the merge commit subject when GitHub has not yet associated the merge commit with its PR.
+- Falls back to parsing only the merge commit subject when GitHub has not yet associated the merge commit with its PR.
+- Validates the PR referenced by the merge subject before tagging, instead of trusting the commit message alone.
+- Warns and continues to the validated merge-subject fallback when the caller omitted `pull-requests: read`.
 - Fails the workflow if the tag already exists (prevents merge from appearing successful).
 
 Inputs:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -734,6 +734,10 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -720,7 +720,7 @@ Notes:
 - Only tags pushes that land on the actual default branch.
 - Falls back to parsing only the merge commit subject when GitHub has not yet associated the merge commit with its PR.
 - Validates the PR referenced by the merge subject before tagging, instead of trusting the commit message alone.
-- Warns and continues to the validated merge-subject fallback when the caller omitted `pull-requests: read`.
+- Warns and may skip tagging when the caller omitted `pull-requests: read`, because both the primary lookup and fallback validation require that permission.
 - Fails the workflow if the tag already exists (prevents merge from appearing successful).
 
 Inputs:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -717,6 +717,8 @@ Purpose: Auto-tag releases when a `release/X.Y.Z` or `release/X.Y.Z-rcN` PR is m
 
 Notes:
 - Detects the repo default branch; falls back to `main` if missing.
+- Only tags pushes that land on the actual default branch.
+- Falls back to parsing the merge commit subject when GitHub has not yet associated the merge commit with its PR.
 - Fails the workflow if the tag already exists (prevents merge from appearing successful).
 
 Inputs:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -720,7 +720,7 @@ Notes:
 - Only tags pushes that land on the actual default branch.
 - Falls back to parsing only the merge commit subject when GitHub has not yet associated the merge commit with its PR.
 - Validates the PR referenced by the merge subject before tagging, instead of trusting the commit message alone.
-- Warns and may skip tagging when the caller omitted `pull-requests: read`, because both the primary lookup and fallback validation require that permission.
+- Warns and skips tagging when the caller omitted `pull-requests: read`, because both the primary lookup and fallback validation require that permission.
 - Fails the workflow if the tag already exists (prevents merge from appearing successful).
 
 Inputs:


### PR DESCRIPTION
## Summary
This release fixes the reusable `auto-tag-release.yml` workflow so downstream repos can keep using `ci-helpers` for release tagging instead of inlining repository-specific fallback logic.

## Problem
Some release merges reached the default branch before GitHub had associated the merge commit with its PR in `listPullRequestsAssociatedWithCommit`. In that case, the reusable workflow logged `No merged PR associated with the latest commit.` and exited without creating the expected release tag.

## Changes
- keep release detection on the reusable workflow in `ci-helpers`
- only allow tagging when the push landed on the actual default branch
- match PR-based detection on `merge_commit_sha === context.sha`
- fall back to parsing the merge commit subject when PR association is delayed
- document the behavior in the workflow docs and changelog

## Why This Fix
This preserves the intended architecture: repositories should consume the reusable auto-tag workflow from `ci-helpers`, and the fallback logic belongs upstream in the shared workflow rather than being duplicated per repo.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/auto-tag-release.yml"); puts "yaml ok"'`

## Impact
After this release, downstream repos can point back to:

```yaml
jobs:
  tag:
    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
```

instead of carrying repo-local auto-tag implementations.
