### PR TITLE
fix: use full repo ref for gitleaks composite action in reusable workflow

### DIFF
--- a/.github/workflows/gitleaks-scan.yml
+++ b/.github/workflows/gitleaks-scan.yml
@@ -57,7 +57,11 @@ jobs:
           fetch-tags: true
 
       - name: Gitleaks scan
-        uses: ./.github/actions/gitleaks-scan
+        # Must use full OWNER/REPO/path@ref — not a relative path.
+        # Reusable workflows called cross-repo resolve ./ against the caller's
+        # checkout, not ci-helpers.  The full reference lets GitHub fetch the
+        # action from this repo regardless of what the runner has checked out.
+        uses: nikolareljin/ci-helpers/.github/actions/gitleaks-scan@production
         with:
           scan_path: ${{ inputs.scan_path }}
           report_format: ${{ inputs.report_format }}


### PR DESCRIPTION
## Problem

`uses: ./.github/actions/gitleaks-scan` (relative path) in `gitleaks-scan.yml` fails when called cross-repo.

GitHub Actions resolves `./` in a reusable workflow against the **caller's checkout** — not ci-helpers. Every caller hit:

```
Can't find 'action.yml' under '/home/runner/work/orthodox-calendar/orthodox-calendar/.github/actions/gitleaks-scan'
```

This was introduced by `1d7b812` which reasoned incorrectly that GitHub resolves relative paths against the workflow's defining repo. The [GitHub Actions docs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) state the opposite: "If a reusable workflow uses a local action, the path must use the full repository path, not a relative path."

## Fix

```yaml
uses: nikolareljin/ci-helpers/.github/actions/gitleaks-scan@production
```

GitHub fetches this action from ci-helpers at the production ref, regardless of what the runner has checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)