### PR TITLE
fix: pin actions/github-script to 3a2844b7 (v9 @ 2026-05-23)

### DIFF
--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -45,7 +45,7 @@ jobs:
       BASE_BRANCH: ${{ github.event_name == 'workflow_call' && inputs.base_branch || '' }}
     steps:
       - name: Create PR to default branch
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9 @ 2026-05-23
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 @ 2026-05-23
         with:
           # Prefer GH_PAT when set — it bypasses the repo-level
           # "Allow GitHub Actions to create and approve pull requests" gate.


### PR DESCRIPTION
## Security Gate failure

The Security Gate on main (run [#26344002204](https://github.com/nikolareljin/ci-helpers/actions/runs/26344002204)) detected one stale SHA pin:

```
STALE .github/workflows/release-rc-pr.yml: actions/github-script
      ref:  v9
      old:  373c709c69115d41ff229c7e5df9f8788daa9553  (2026-05-23)
      new:  3a2844b7e9c422d3c10d287c895573f7108da1b3  (2026-05-23)
```

## Fix

Updates the SHA pin in `release-rc-pr.yml` to `3a2844b7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)