### PR TITLE
fix: replace all ./ relative refs with full repo paths in reusable workflows

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/java-gradle.yml
+++ b/.github/workflows/java-gradle.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/pimcore.yml
+++ b/.github/workflows/pimcore.yml
@@ -75,7 +75,7 @@ on:
 
 jobs:
   pimcore-bundle:
-    uses: ./.github/workflows/pimcore-bundle-check.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/pimcore-bundle-check.yml@production
     with:
       runner: ${{ inputs.runner }}
       compose_file: ${{ inputs.compose_file }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       runner: ${{ inputs.runner }}
       working_directory: ${{ inputs.working_directory }}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -253,7 +253,7 @@ jobs:
 
       - name: Configure macOS codesigning
         if: ${{ inputs.sign_macos }}
-        uses: ./.github/actions/macos-sign
+        uses: nikolareljin/ci-helpers/.github/actions/macos-sign@production
         with:
           certificate_base64: ${{ secrets.APPLE_CERTIFICATE }}
           certificate_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -400,7 +400,7 @@ jobs:
 
       - name: Configure Windows signing
         if: ${{ inputs.windows_sign_mode != 'none' }}
-        uses: ./.github/actions/windows-sign
+        uses: nikolareljin/ci-helpers/.github/actions/windows-sign@production
         with:
           sign_mode: ${{ inputs.windows_sign_mode }}
           tauri_signing_private_key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -651,7 +651,7 @@ jobs:
   winget-submit:
     needs: release
     if: ${{ inputs.winget_submit && inputs.winget_package_id != '' && inputs.winget_installer_url != '' && inputs.winget_fork_owner != '' }}
-    uses: ./.github/workflows/winget-submit.yml
+    uses: nikolareljin/ci-helpers/.github/workflows/winget-submit.yml@production
     with:
       package_id: ${{ inputs.winget_package_id }}
       version: ${{ inputs.version != '' && inputs.version || github.ref_name }}


### PR DESCRIPTION
## Problem

GitHub Actions resolves `./` paths in reusable workflows (`on: workflow_call`) against the **caller's checkout**, not the workflow's defining repo. Any `uses: ./path` inside a reusable workflow fails when that workflow is called cross-repo.

This was the root cause of the gitleaks CI failure in orthodox-calendar (fixed in #50). A full audit of ci-helpers found the same pattern in 15 more files.

## Affected files

### Step-level composite action refs in reusable workflows (same pattern as the gitleaks bug)
| File | Broken ref |
|------|-----------|
| `tauri-release.yml` | `./.github/actions/macos-sign` |
| `tauri-release.yml` | `./.github/actions/windows-sign` |

### Job-level nested reusable workflow refs (GitHub docs: "must use full OWNER/REPO/path@ref")
| File | Broken ref |
|------|-----------|
| `tauri-release.yml` | `./.github/workflows/winget-submit.yml` |
| `pimcore.yml` | `./.github/workflows/pimcore-bundle-check.yml` |
| `kotlin.yml`, `csharp.yml`, `node.yml`, `php.yml`, `docker.yml`, `python.yml`, `rust.yml`, `react.yml`, `java.yml`, `java-gradle.yml`, `playwright.yml`, `go.yml`, `cypress.yml` | `./.github/workflows/ci.yml` |

## Not changed

`gitleaks-check.yml`, `security-weekly.yml`, `release-tag-check.yml`, `auto-tag-release-push.yml` — internal-only workflows (no `workflow_call` trigger); their `./` refs are correct.

## Fix

All broken refs replaced with `nikolareljin/ci-helpers/.github/...\@production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)