### PR TITLE
fix: require Android signing secrets only when deploying to Google Play

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -124,12 +124,15 @@ jobs:
         run: flutter pub get
 
       - name: Validate Android signing secrets
-        if: ${{ inputs.deploy_google_play }}
+        if: ${{ inputs.build_android || inputs.deploy_google_play }}
         run: |
           set -euo pipefail
           if [[ -z "${ANDROID_KEYSTORE_BASE64}" || -z "${ANDROID_KEYSTORE_PASSWORD}" || -z "${ANDROID_KEY_PASSWORD}" || -z "${ANDROID_KEY_ALIAS}" ]]; then
-            echo "Missing Android signing secrets. Provide android_keystore_base64, android_keystore_password, android_key_password, and android_key_alias." >&2
-            exit 1
+            if [[ "${{ inputs.deploy_google_play }}" == "true" ]]; then
+              echo "Missing Android signing secrets. Provide android_keystore_base64, android_keystore_password, android_key_password, and android_key_alias." >&2
+              exit 1
+            fi
+            echo "::warning::No Android signing secrets provided; build will use the project's default signing config."
           fi
 
       - name: Validate Google Play credentials
@@ -155,9 +158,13 @@ jobs:
           fi
 
       - name: Configure Android signing
-        if: ${{ inputs.deploy_google_play }}
+        if: ${{ inputs.build_android || inputs.deploy_google_play }}
         run: |
           set -euo pipefail
+          if [[ -z "${ANDROID_KEYSTORE_BASE64}" ]]; then
+            echo "No signing secrets; skipping key.properties setup."
+            exit 0
+          fi
           set +x
           umask 077
           {

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -124,7 +124,7 @@ jobs:
         run: flutter pub get
 
       - name: Validate Android signing secrets
-        if: ${{ inputs.build_android || inputs.deploy_google_play }}
+        if: ${{ inputs.deploy_google_play }}
         run: |
           set -euo pipefail
           if [[ -z "${ANDROID_KEYSTORE_BASE64}" || -z "${ANDROID_KEYSTORE_PASSWORD}" || -z "${ANDROID_KEY_PASSWORD}" || -z "${ANDROID_KEY_ALIAS}" ]]; then
@@ -155,7 +155,7 @@ jobs:
           fi
 
       - name: Configure Android signing
-        if: ${{ inputs.build_android || inputs.deploy_google_play }}
+        if: ${{ inputs.deploy_google_play }}
         run: |
           set -euo pipefail
           set +x
@@ -179,7 +179,7 @@ jobs:
           set -x
 
       - name: Note for Android signing config
-        if: ${{ inputs.build_android || inputs.deploy_google_play }}
+        if: ${{ inputs.deploy_google_play }}
         run: |
           echo "Android signing expects android/key.properties at the Flutter project's android/ directory."
           echo "Ensure android/app/build.gradle loads it via: rootProject.file('key.properties')"


### PR DESCRIPTION
## Summary

- Android signing validation (validate step) was failing with \`exit 1\` whenever \`build_android: true\` and signing secrets were absent, blocking CI builds that use debug or gradle-managed signing
- Fix: warn instead of fail when secrets are missing AND \`deploy_google_play\` is false; hard-fail is preserved for deployment
- Configure step: skip \`key.properties\` setup gracefully when \`ANDROID_KEYSTORE_BASE64\` is empty (instead of base64-decode failing on empty string)
- Both steps still gate on \`build_android || deploy_google_play\`, so custom signing IS configured whenever secrets are provided

## Behavior matrix

| build_android | deploy_google_play | secrets | Result |
|---|---|---|---|
| true | false | absent | ⚠️ warning, build uses project's default signing |
| true | false | present | ✅ key.properties set up, custom signing used |
| false | true | absent | ❌ validation fails (required for Play Store) |
| true | true | present | ✅ full signing + deployment |

## Motivation

R-900 PR #2: repo uses \`signingConfig = signingConfigs.getByName("debug")\` in \`build.gradle.kts\`, so CI builds don't need keystore secrets but were failing on the validation gate.
