### PR TITLE
feat(deb-build): upload .deb to GitHub release on tag push

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -26,6 +26,27 @@ on:
       artifact_glob:
         type: string
         default: "../*.deb"
+      upload_to_release:
+        description: >
+          Upload the built .deb to the GitHub release. Set to "true" to always
+          upload, "false" to never upload, or "auto" (default) to upload only
+          when the workflow was triggered by a tag push or a release_tag input
+          is provided.
+        type: string
+        default: "auto"
+      release_tag:
+        description: >
+          Tag to attach the .deb to. Defaults to the pushed tag (GITHUB_REF_NAME).
+          Set explicitly when triggering via workflow_dispatch with a backfill tag.
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+# Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
@@ -38,6 +59,8 @@ jobs:
 
       - name: Install packaging prerequisites
         shell: bash
+        env:
+          EXTRA_PACKAGES: ${{ inputs.extra_packages }}
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -47,8 +70,8 @@ jobs:
             devscripts \
             dh-python \
             python3
-          if [ -n "${{ inputs.extra_packages }}" ]; then
-            sudo apt-get install -y ${{ inputs.extra_packages }}
+          if [ -n "${EXTRA_PACKAGES:-}" ]; then
+            sudo apt-get install -y $EXTRA_PACKAGES
           fi
 
       - name: Bootstrap script-helpers
@@ -69,15 +92,49 @@ jobs:
       - name: Build package
         shell: bash
         working-directory: ${{ inputs.working_directory }}
+        env:
+          PREBUILD_CMD: ${{ inputs.prebuild_command }}
+          BUILD_CMD: ${{ inputs.build_command }}
+          WORKING_DIR: ${{ inputs.working_directory }}
         run: |
           set -euo pipefail
           ./vendor/script-helpers/scripts/build_deb_artifacts.sh \
-            --repo "${{ inputs.working_directory }}" \
-            --prebuild "${{ inputs.prebuild_command }}" \
-            --build "${{ inputs.build_command }}"
+            --repo "$WORKING_DIR" \
+            --prebuild "$PREBUILD_CMD" \
+            --build "$BUILD_CMD"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_glob }}
+
+      - name: Resolve release tag
+        id: resolve
+        if: inputs.upload_to_release != 'false'
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+          UPLOAD_MODE: ${{ inputs.upload_to_release }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
+          # "auto": only upload when the ref is a tag or release_tag was given
+          if [[ "$UPLOAD_MODE" == "auto" ]]; then
+            if ! echo "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"   >> "$GITHUB_OUTPUT"
+
+      - name: Upload .deb to GitHub release
+        if: inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.resolve.outputs.tag }}
+          files: ${{ inputs.artifact_glob }}
+          update_existing: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `upload_to_release` input (`auto` / `true` / `false`, default: `auto`) — when `auto`, uploads the built `.deb` to the GitHub release whenever the ref is a version tag or `release_tag` is provided
- Adds `release_tag` input for manual backfill via `workflow_dispatch`
- Fixes injection risk in `extra_packages` step (now via env var)
- Fixes injection risk in `prebuild_command` / `build_command` (now via env vars)
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env for Node 20 deprecation

## Before / After

**Before:** `.deb` was only stored as a workflow artifact — never in the GitHub release.  
**After:** `.deb` is uploaded to the release automatically on every tag push.

## Callers

Any existing caller that doesn't pass `upload_to_release` gets `auto` behavior — uploads only on version tags, skips on branch pushes. Zero breaking changes.