### PR TITLE
fix: bump securego/gosec SHA pin (security-weekly unblock)

### DIFF
--- a/.github/workflows/go-scan.yml
+++ b/.github/workflows/go-scan.yml
@@ -56,6 +56,6 @@ jobs:
 
       - name: Gosec scan
         if: ${{ inputs.gosec_args != '' }}
-        uses: securego/gosec@92ed8df32846e85d4e81b0b62012567afddfdc95 # master @ 2026-06-04
+        uses: securego/gosec@f1c81de5fcdf7b466b229fb24ca02d1a8406dd09 # master @ 2026-06-08
         with:
           args: ${{ inputs.gosec_args }}


### PR DESCRIPTION
## Summary

- Updates `securego/gosec` pin in `go-scan.yml` from `92ed8df` (2026-06-04) to `f1c81de` (2026-06-08)

## Why

`security-weekly.yml` SHA Pin Audit has been failing since 2026-06-08 with:

```
STALE .github/workflows/go-scan.yml: securego/gosec
      old:  92ed8df32846e85d4e81b0b62012567afddfdc95  (2026-06-04)
Summary: 40 up-to-date, 1 stale, 0 warnings.
```

## Test plan

- [ ] Merge → verify next `security-weekly` run passes SHA Pin Audit