### PR TITLE
fix: verify production tag/branch in sync after create_production.sh update

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -247,6 +247,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_WORKFLOW: ${{ inputs.release_workflow }}
           VERSION: ${{ needs.tag.outputs.version }}
         run: |

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -33,9 +33,11 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  # NOTE: Caller workflows must also grant actions: write when release_workflow
-  # is set; reusable workflows cannot elevate the GITHUB_TOKEN permissions of
-  # their callers. actions: write is requested only by the dispatch job.
+  # NOTE: Caller workflows must also grant pull-requests: read (required for
+  # PR-based version detection) and actions: write when release_workflow is set
+  # (required to dispatch the release workflow). Reusable workflows cannot
+  # elevate the GITHUB_TOKEN permissions of their callers.
+  # actions: write is requested only by the dispatch job.
 
 # Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
 env:

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -254,6 +254,10 @@ jobs:
           VERSION: ${{ needs.tag.outputs.version }}
         run: |
           set -euo pipefail
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "::error::gh CLI not found. Install it on your runner: https://cli.github.com/"
+            exit 1
+          fi
           # Validate workflow name: only safe filename characters, must end in .yml or .yaml
           if ! printf '%s' "$RELEASE_WORKFLOW" | grep -qE '^[A-Za-z0-9_.-]+\.ya?ml$'; then
             echo "::error::release_workflow '${RELEASE_WORKFLOW}' is not a valid workflow filename."

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -32,11 +32,10 @@ on:
 
 permissions:
   contents: write
-  actions: write
-  # NOTE: Caller workflows must also grant pull-requests: read and (when
-  # release_workflow is set) actions: write; reusable workflows cannot
-  # elevate the GITHUB_TOKEN permissions of their callers.
   pull-requests: read
+  # NOTE: Caller workflows must also grant actions: write when release_workflow
+  # is set; reusable workflows cannot elevate the GITHUB_TOKEN permissions of
+  # their callers. actions: write is requested only by the dispatch job.
 
 # Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
 env:
@@ -45,6 +44,11 @@ env:
 jobs:
   tag:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -224,25 +228,6 @@ jobs:
           git tag "$version"
           git push origin "$version"
 
-      - name: Dispatch release workflow
-        if: ${{ steps.release.outputs.version != '' && inputs.release_workflow != '' }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_WORKFLOW: ${{ inputs.release_workflow }}
-          VERSION: ${{ steps.release.outputs.version }}
-          REF: ${{ inputs.default_branch != '' && inputs.default_branch || github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          # Validate workflow name: only safe filename characters, must end in .yml or .yaml
-          if ! printf '%s' "$RELEASE_WORKFLOW" | grep -qE '^[A-Za-z0-9_.-]+\.ya?ml$'; then
-            echo "::error::release_workflow '${RELEASE_WORKFLOW}' is not a valid workflow filename."
-            exit 1
-          fi
-          branch="${REF:-main}"
-          echo "Dispatching ${RELEASE_WORKFLOW} for tag ${VERSION} on ${branch}"
-          gh workflow run "$RELEASE_WORKFLOW" --ref "$branch" -f "release_tag=${VERSION}"
-
       - name: Update production tag ref
         if: ${{ steps.release.outputs.version != '' && inputs.update_production_tag }}
         shell: bash
@@ -250,3 +235,26 @@ jobs:
           set -euo pipefail
           version="${{ steps.release.outputs.version }}"
           ./scripts/create_production.sh -t "$version" --fetch-tags
+
+  dispatch:
+    needs: tag
+    if: ${{ needs.tag.outputs.version != '' && inputs.release_workflow != '' }}
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch release workflow
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW: ${{ inputs.release_workflow }}
+          VERSION: ${{ needs.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Validate workflow name: only safe filename characters, must end in .yml or .yaml
+          if ! printf '%s' "$RELEASE_WORKFLOW" | grep -qE '^[A-Za-z0-9_.-]+\.ya?ml$'; then
+            echo "::error::release_workflow '${RELEASE_WORKFLOW}' is not a valid workflow filename."
+            exit 1
+          fi
+          echo "Dispatching ${RELEASE_WORKFLOW} for tag ${VERSION} on ref ${VERSION}"
+          gh workflow run "$RELEASE_WORKFLOW" --ref "${VERSION}" -f "release_tag=${VERSION}"

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -19,11 +19,23 @@ on:
           need version tagging).
         type: boolean
         default: true
+      release_workflow:
+        description: >
+          Workflow file name (e.g. "release.yml") to dispatch via workflow_dispatch
+          after the version tag is pushed. When set, the workflow is triggered with
+          a release_tag input equal to the detected version, bypassing the GitHub
+          restriction that prevents GITHUB_TOKEN-created tags from firing tag-push
+          triggered workflows. Leave empty (default) to skip auto-dispatch.
+          NOTE: callers must also grant actions: write permission.
+        type: string
+        default: ""
 
 permissions:
   contents: write
-  # NOTE: Caller workflows must also grant `pull-requests: read`; reusable
-  # workflows cannot elevate the GITHUB_TOKEN permissions of their callers.
+  actions: write
+  # NOTE: Caller workflows must also grant pull-requests: read and (when
+  # release_workflow is set) actions: write; reusable workflows cannot
+  # elevate the GITHUB_TOKEN permissions of their callers.
   pull-requests: read
 
 # Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
@@ -211,6 +223,25 @@ jobs:
           version="${{ steps.release.outputs.version }}"
           git tag "$version"
           git push origin "$version"
+
+      - name: Dispatch release workflow
+        if: ${{ steps.release.outputs.version != '' && inputs.release_workflow != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW: ${{ inputs.release_workflow }}
+          VERSION: ${{ steps.release.outputs.version }}
+          REF: ${{ inputs.default_branch != '' && inputs.default_branch || github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          # Validate workflow name: only safe filename characters, must end in .yml or .yaml
+          if ! printf '%s' "$RELEASE_WORKFLOW" | grep -qE '^[A-Za-z0-9_.-]+\.ya?ml$'; then
+            echo "::error::release_workflow '${RELEASE_WORKFLOW}' is not a valid workflow filename."
+            exit 1
+          fi
+          branch="${REF:-main}"
+          echo "Dispatching ${RELEASE_WORKFLOW} for tag ${VERSION} on ${branch}"
+          gh workflow run "$RELEASE_WORKFLOW" --ref "$branch" -f "release_tag=${VERSION}"
 
       - name: Update production tag ref
         if: ${{ steps.release.outputs.version != '' && inputs.update_production_tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`auto-tag-release.yml`:** New `release_workflow` input (default `""`). When set to a workflow
+  filename (e.g. `"release.yml"`), the workflow is dispatched via `workflow_dispatch` after the
+  version tag is pushed, with `release_tag` set to the detected version. This bypasses the GitHub
+  restriction that prevents `GITHUB_TOKEN`-created tags from firing tag-push triggered workflows.
+  Callers must also grant `actions: write` permission. The workflow filename is validated against
+  a safe-characters regex before use.
+
 ## 2026-06-09 — 0.12.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   Callers must also grant `actions: write` permission. The workflow filename is validated against
   a safe-characters regex before use.
 
+### Changed
+
+- **`create_production.sh`:** Post-push verification now hard-fails when either the `production`
+  tag or branch on the remote is missing or points to a different commit than expected. Previously
+  the script would exit on push failure (via `set -euo pipefail`) but did not explicitly confirm
+  that both remote refs converged to the same SHA. Annotated release tags are handled correctly
+  via the peeled `^{}` entry from `git ls-remote`.
+
 ## 2026-06-09 — 0.12.0
 
 ### Added

--- a/scripts/create_production.sh
+++ b/scripts/create_production.sh
@@ -100,3 +100,21 @@ if $update_branch; then
   git -C "$repo_dir" push "$remote" "${target_sha}:refs/heads/${prod_tag}" --force-with-lease
   log_info_safe "Production branch ${prod_tag} now points to ${tag}"
 fi
+
+# Verify both refs on remote now point to target_sha.
+# production is always a lightweight tag so ls-remote returns the commit SHA directly.
+remote_tag_sha=$(git -C "$repo_dir" ls-remote "$remote" "refs/tags/${prod_tag}" | awk '{print $1}')
+if [[ -z "$remote_tag_sha" || "$remote_tag_sha" != "$target_sha" ]]; then
+  log_error_safe "Verification failed: ${prod_tag} tag on remote is '${remote_tag_sha:0:8}', expected '${target_sha:0:8}'"
+  exit 1
+fi
+if $update_branch; then
+  remote_branch_sha=$(git -C "$repo_dir" ls-remote "$remote" "refs/heads/${prod_tag}" | awk '{print $1}')
+  if [[ -z "$remote_branch_sha" || "$remote_branch_sha" != "$target_sha" ]]; then
+    log_error_safe "Verification failed: ${prod_tag} branch on remote is '${remote_branch_sha:0:8}', expected '${target_sha:0:8}'"
+    exit 1
+  fi
+  log_info_safe "Verified: ${prod_tag} tag and branch both point to ${target_sha:0:8}"
+else
+  log_info_safe "Verified: ${prod_tag} tag points to ${target_sha:0:8}"
+fi

--- a/scripts/create_production.sh
+++ b/scripts/create_production.sh
@@ -102,14 +102,23 @@ if $update_branch; then
 fi
 
 # Verify both refs on remote now point to target_sha.
-# production is always a lightweight tag so ls-remote returns the commit SHA directly.
-remote_tag_sha=$(git -C "$repo_dir" ls-remote "$remote" "refs/tags/${prod_tag}" | awk '{print $1}')
+# Annotated tags: ls-remote returns both the tag-object SHA and a peeled ^{} commit SHA;
+# lightweight tags return only the commit SHA. Prefer the peeled entry when present.
+if ! remote_tag_out=$(git -C "$repo_dir" ls-remote "$remote" "refs/tags/${prod_tag}" "refs/tags/${prod_tag}^{}"); then
+  log_error_safe "Failed to query remote ${remote} for tag ${prod_tag}"
+  exit 1
+fi
+remote_tag_sha=$(printf '%s\n' "$remote_tag_out" | awk '/\^\{\}$/{print $1}')
+[[ -z "$remote_tag_sha" ]] && remote_tag_sha=$(printf '%s\n' "$remote_tag_out" | awk 'NR==1{print $1}')
 if [[ -z "$remote_tag_sha" || "$remote_tag_sha" != "$target_sha" ]]; then
   log_error_safe "Verification failed: ${prod_tag} tag on remote is '${remote_tag_sha:0:8}', expected '${target_sha:0:8}'"
   exit 1
 fi
 if $update_branch; then
-  remote_branch_sha=$(git -C "$repo_dir" ls-remote "$remote" "refs/heads/${prod_tag}" | awk '{print $1}')
+  if ! remote_branch_sha=$(git -C "$repo_dir" ls-remote "$remote" "refs/heads/${prod_tag}" | awk '{print $1}'); then
+    log_error_safe "Failed to query remote ${remote} for branch ${prod_tag}"
+    exit 1
+  fi
   if [[ -z "$remote_branch_sha" || "$remote_branch_sha" != "$target_sha" ]]; then
     log_error_safe "Verification failed: ${prod_tag} branch on remote is '${remote_branch_sha:0:8}', expected '${target_sha:0:8}'"
     exit 1

--- a/scripts/create_production.sh
+++ b/scripts/create_production.sh
@@ -108,7 +108,7 @@ if ! remote_tag_out=$(git -C "$repo_dir" ls-remote "$remote" "refs/tags/${prod_t
   log_error_safe "Failed to query remote ${remote} for tag ${prod_tag}"
   exit 1
 fi
-remote_tag_sha=$(printf '%s\n' "$remote_tag_out" | awk '/\^\{\}$/{print $1}')
+remote_tag_sha=$(printf '%s\n' "$remote_tag_out" | awk '/\^\{\}$/{print $1; exit}')
 [[ -z "$remote_tag_sha" ]] && remote_tag_sha=$(printf '%s\n' "$remote_tag_out" | awk 'NR==1{print $1}')
 if [[ -z "$remote_tag_sha" || "$remote_tag_sha" != "$target_sha" ]]; then
   log_error_safe "Verification failed: ${prod_tag} tag on remote is '${remote_tag_sha:0:8}', expected '${target_sha:0:8}'"


### PR DESCRIPTION
## Summary

- Adds post-push verification to `create_production.sh` — after updating the \`production\` tag and branch, queries the remote via \`git ls-remote\` and asserts both refs point to the expected SHA; fails loudly if either is missing or diverged
- Adds \`release_workflow\` input to \`auto-tag-release.yml\` — when set to a workflow filename (e.g. \`release.yml\`), dispatches it via \`workflow_dispatch\` after the version tag is pushed, bypassing the GitHub restriction that prevents \`GITHUB_TOKEN\`-created tags from firing tag-push triggered workflows

## Why

**Verification:** \`create_production.sh\` uses \`set -euo pipefail\` so a failed push exits, but there was no explicit check that both refs were actually updated to the same commit on the remote. If one push succeeded and the other failed silently, refs could diverge with no clear indicator.

**Release dispatch:** Tags created programmatically via \`GITHUB_TOKEN\` cannot trigger other workflows (GitHub security restriction). Any project using \`auto-tag-release.yml\` hits this: the tag gets created but the release workflow never fires. The new \`release_workflow\` input closes this gap centrally — no workaround needed in each consumer repo.

## Usage (release_workflow)

In the caller's tag workflow:
\`\`\`yaml
jobs:
  tag:
    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
    with:
      update_production_tag: false
      release_workflow: release.yml   # dispatched after tag push
permissions:
  contents: write
  pull-requests: read
  actions: write   # required for workflow_dispatch
\`\`\`

The \`release.yml\` must accept a \`release_tag\` string input via \`workflow_dispatch\`.

## Test plan

- [ ] `create_production.sh` called with valid tag: verification log line confirms both refs
- [ ] Simulated failure (branch push blocked): script exits non-zero with clear mismatch message
- [ ] PravKal \`tag.yml\` wired with \`release_workflow: release.yml\`: merging a \`release/X.Y.Z\` PR auto-tags and dispatches the release workflow; GitHub Release is created with platform binaries