### PR TITLE
fix: restore actions:write to workflow-level permissions (startup_failure)

### DIFF
--- a/.github/workflows/auto-tag-release-push.yml
+++ b/.github/workflows/auto-tag-release-push.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  actions: write
 
 jobs:
   tag:

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -33,11 +33,14 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  # NOTE: Caller workflows must also grant pull-requests: read (required for
-  # PR-based version detection) and actions: write when release_workflow is set
-  # (required to dispatch the release workflow). Reusable workflows cannot
+  # actions: write must appear here so the dispatch job can request it at the
+  # job level (GitHub requires job-level permissions ⊆ workflow-level permissions).
+  # The tag job's explicit permissions block excludes it, so it only applies to
+  # the dispatch job.
+  # NOTE: Callers must also grant pull-requests: read (PR-based version detection)
+  # and actions: write when release_workflow is set. Reusable workflows cannot
   # elevate the GITHUB_TOKEN permissions of their callers.
-  # actions: write is requested only by the dispatch job.
+  actions: write
 
 # Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   Callers must also grant `actions: write` permission. The workflow filename is validated against
   a safe-characters regex before use.
 
+### Fixed
+
+- **`auto-tag-release.yml`:** Restored `actions: write` to the workflow-level `permissions:` block.
+  GitHub requires job-level permissions to be a strict subset of the workflow-level block; omitting
+  `actions: write` from the top-level while the `dispatch` job requested it at job-level caused a
+  `startup_failure` on every invocation of the workflow.
+
 ### Changed
 
 - **`create_production.sh`:** Post-push verification now hard-fails when either the `production`


### PR DESCRIPTION
## Summary

- Restores `actions: write` to the top-level `permissions:` block of `auto-tag-release.yml`
- GitHub requires job-level permissions to be a strict **subset** of the workflow-level block; when PR #78 moved `actions: write` exclusively to the `dispatch` job-level block (removing it from the top), every call to the workflow failed with `startup_failure` before any job ran
- The `tag` job still has its own explicit `permissions:` block that excludes `actions: write`, so least-privilege is preserved there

## Root cause

```
# workflow-level (PR #78 result — missing actions:write)
permissions:
  contents: write
  pull-requests: read

# dispatch job (requests actions:write, not in ceiling → startup_failure)
jobs:
  dispatch:
    permissions:
      actions: write   # ❌ not a subset of workflow-level
```

## Test plan

- [ ] Push triggers `auto-tag-release-push` without `startup_failure`
- [ ] Non-release merges to main: workflow runs, detects no version, exits cleanly
- [ ] Release merge (e.g. `release/0.13.0` → main via squash or merge): version detected, tag + production refs updated