### PR TITLE
fix: handle 403 in release-rc-pr gracefully

### DIFF
--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -101,7 +101,7 @@ jobs:
               // Anything else (abuse detection, SSO policy, unknown causes) fails hard.
               const permissionDeniedPatterns = [
                 'not permitted to create',               // Actions setting disabled
-                'resource not accessible by integration', // token lacks pull-requests:write
+                'resource not accessible by integration', // token lacks pull-requests: write
                 'pull requests are disabled',             // PRs disabled on the repo
               ];
               const isPermissionDenied = status === 403 &&
@@ -113,7 +113,7 @@ jobs:
                   `Possible causes and remediations:\n` +
                   `  1. Repo setting disabled: enable "Allow GitHub Actions to create and approve pull requests"\n` +
                   `     under Settings → Actions → General.\n` +
-                  `  2. Caller token lacks pull-requests: write: ensure the calling workflow grants\n` +
+                  `  2. Caller token lacks pull-requests: write — ensure the calling workflow grants\n` +
                   `     permissions: pull-requests: write (for workflow_call).\n` +
                   `  3. No PAT configured: set the GH_PAT secret to a classic PAT with the repo scope,\n` +
                   `     or a fine-grained PAT with "Pull requests: Read and write" permission.\n` +

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -93,9 +93,10 @@ jobs:
               const status = typeof err === 'object' && err !== null && 'status' in err
                 ? Number(err.status)
                 : NaN;
-              const message = typeof err === 'object' && err !== null && typeof err.message === 'string'
-                ? err.message.toLowerCase()
+              const rawMessage = typeof err === 'object' && err !== null && typeof err.message === 'string'
+                ? err.message
                 : '';
+              const message = rawMessage.toLowerCase();
               // Allowlist of known permission/config 403s that are safe to soft-warn.
               // Anything else (abuse detection, SSO policy, unknown causes) fails hard.
               const permissionDeniedPatterns = [
@@ -108,6 +109,7 @@ jobs:
               if (isPermissionDenied) {
                 core.warning(
                   `Could not create PR for ${head} -> ${base} (403 Forbidden).\n` +
+                  `API error: ${rawMessage}\n` +
                   `Possible causes and remediations:\n` +
                   `  1. Repo setting disabled: enable "Allow GitHub Actions to create and approve pull requests"\n` +
                   `     under Settings → Actions → General.\n` +

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -90,7 +90,12 @@ jobs:
               await github.rest.pulls.create({ owner, repo, head, base, title, body });
               core.info(`Created PR ${head} -> ${base}`);
             } catch (err) {
-              if (err.status === 403) {
+              const status = err?.status;
+              const message = typeof err?.message === 'string' ? err.message : '';
+              // Soft-warn only for the known "Actions not permitted to create PRs" 403.
+              // Other 403s (abuse detection, secondary rate limits) should still fail hard.
+              const isPermissionDenied = status === 403 && !message.includes('secondary rate limit') && !message.includes('abuse');
+              if (isPermissionDenied) {
                 core.warning(
                   `Could not create PR for ${head} -> ${base} (403 Forbidden).\n` +
                   `Possible causes and remediations:\n` +

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -91,10 +91,16 @@ jobs:
               core.info(`Created PR ${head} -> ${base}`);
             } catch (err) {
               const status = err?.status;
-              const message = typeof err?.message === 'string' ? err.message : '';
-              // Soft-warn only for the known "Actions not permitted to create PRs" 403.
-              // Other 403s (abuse detection, secondary rate limits) should still fail hard.
-              const isPermissionDenied = status === 403 && !message.includes('secondary rate limit') && !message.includes('abuse');
+              const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
+              // Allowlist of known permission/config 403s that are safe to soft-warn.
+              // Anything else (abuse detection, SSO policy, unknown causes) fails hard.
+              const PERMISSION_DENIED_PATTERNS = [
+                'not permitted to create',          // Actions setting disabled
+                'resource not accessible by integration', // token lacks pull-requests:write
+                'pull requests are disabled',        // PRs disabled on the repo
+              ];
+              const isPermissionDenied = status === 403 &&
+                PERMISSION_DENIED_PATTERNS.some(p => message.includes(p));
               if (isPermissionDenied) {
                 core.warning(
                   `Could not create PR for ${head} -> ${base} (403 Forbidden).\n` +

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -86,5 +86,18 @@ jobs:
             const title = `Release: ${head}`;
             const body  = `Auto-created PR for release branch \`${head}\` into \`${base}\`.`;
 
-            await github.rest.pulls.create({ owner, repo, head, base, title, body });
-            core.info(`Created PR ${head} -> ${base}`);
+            try {
+              await github.rest.pulls.create({ owner, repo, head, base, title, body });
+              core.info(`Created PR ${head} -> ${base}`);
+            } catch (err) {
+              if (err.status === 403) {
+                core.warning(
+                  `Could not create PR: GitHub Actions is not permitted to create pull requests in this repository.\n` +
+                  `To fix: enable "Allow GitHub Actions to create and approve pull requests" under Settings → Actions → General, ` +
+                  `or set the GH_PAT secret to a PAT with pull-requests:write access.\n` +
+                  `Create the PR manually: ${head} -> ${base}`
+                );
+                return;
+              }
+              throw err;
+            }

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -90,17 +90,21 @@ jobs:
               await github.rest.pulls.create({ owner, repo, head, base, title, body });
               core.info(`Created PR ${head} -> ${base}`);
             } catch (err) {
-              const status = err?.status;
-              const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
+              const status = typeof err === 'object' && err !== null && 'status' in err
+                ? Number(err.status)
+                : NaN;
+              const message = typeof err === 'object' && err !== null && typeof err.message === 'string'
+                ? err.message.toLowerCase()
+                : '';
               // Allowlist of known permission/config 403s that are safe to soft-warn.
               // Anything else (abuse detection, SSO policy, unknown causes) fails hard.
-              const PERMISSION_DENIED_PATTERNS = [
-                'not permitted to create',          // Actions setting disabled
+              const permissionDeniedPatterns = [
+                'not permitted to create',               // Actions setting disabled
                 'resource not accessible by integration', // token lacks pull-requests:write
-                'pull requests are disabled',        // PRs disabled on the repo
+                'pull requests are disabled',             // PRs disabled on the repo
               ];
               const isPermissionDenied = status === 403 &&
-                PERMISSION_DENIED_PATTERNS.some(p => message.includes(p));
+                permissionDeniedPatterns.some(p => message.includes(p));
               if (isPermissionDenied) {
                 core.warning(
                   `Could not create PR for ${head} -> ${base} (403 Forbidden).\n` +

--- a/.github/workflows/release-rc-pr.yml
+++ b/.github/workflows/release-rc-pr.yml
@@ -92,9 +92,14 @@ jobs:
             } catch (err) {
               if (err.status === 403) {
                 core.warning(
-                  `Could not create PR: GitHub Actions is not permitted to create pull requests in this repository.\n` +
-                  `To fix: enable "Allow GitHub Actions to create and approve pull requests" under Settings → Actions → General, ` +
-                  `or set the GH_PAT secret to a PAT with pull-requests:write access.\n` +
+                  `Could not create PR for ${head} -> ${base} (403 Forbidden).\n` +
+                  `Possible causes and remediations:\n` +
+                  `  1. Repo setting disabled: enable "Allow GitHub Actions to create and approve pull requests"\n` +
+                  `     under Settings → Actions → General.\n` +
+                  `  2. Caller token lacks pull-requests: write: ensure the calling workflow grants\n` +
+                  `     permissions: pull-requests: write (for workflow_call).\n` +
+                  `  3. No PAT configured: set the GH_PAT secret to a classic PAT with the repo scope,\n` +
+                  `     or a fine-grained PAT with "Pull requests: Read and write" permission.\n` +
                   `Create the PR manually: ${head} -> ${base}`
                 );
                 return;


### PR DESCRIPTION
## Summary

- \`release-rc-pr.yml\` was failing the job with an unhandled 403 when the repo has **Allow GitHub Actions to create and approve pull requests** disabled and \`GH_PAT\` is not set
- Wraps \`github.rest.pulls.create()\` in a try/catch; on a **known permission/config 403** (allowlisted message substrings) emits a \`core.warning\` with actionable instructions and returns cleanly — unknown 403s (abuse detection, SSO enforcement, etc.) and all other errors are still re-thrown so genuine failures surface

## Root cause

\`\`\`
// before — unhandled throw on any 403
await github.rest.pulls.create({ ... });

// after — known permission 403s are a soft warning; everything else propagates
try {
  await github.rest.pulls.create({ ... });
} catch (err) {
  const status = Number(err.status);
  const isKnownPermission403 = status === 403 &&
    permissionDeniedPatterns.some(p => err.message.toLowerCase().includes(p));
  if (isKnownPermission403) { core.warning(...); return; }
  throw err;
}
\`\`\`

Soft-warned patterns (case-insensitive substrings of the API error message):
- `not permitted to create` — Actions setting disabled
- `resource not accessible by integration` — token lacks \`pull-requests: write\`
- `pull requests are disabled` — PRs disabled on the repo

## Test plan

- [ ] Push a \`release/*\` branch in a repo with the setting disabled and no \`GH_PAT\` → job passes with a warning including the API error text, no PR created
- [ ] Push a \`release/*\` branch in a repo with the setting enabled → PR created as before
- [ ] Simulate an unknown 403 (e.g. SSO) → job fails hard (error is re-thrown)