### PR TITLE
feat: auto-create GitHub Release after version tag push

### DIFF
--- a/.github/workflows/auto-tag-release-push.yml
+++ b/.github/workflows/auto-tag-release-push.yml
@@ -13,3 +13,5 @@ permissions:
 jobs:
   tag:
     uses: ./.github/workflows/auto-tag-release.yml
+    with:
+      release_workflow: create-github-release.yml

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -96,7 +96,6 @@ jobs:
           tag_name: ${{ steps.resolve_tag.outputs.tag }}
           name: ${{ steps.resolve_tag.outputs.tag }}
           body: ${{ steps.notes.outputs.body }}
-          update_existing: true
 
       - name: Create GitHub Release (auto-generated notes)
         if: steps.notes.outputs.body == ''
@@ -105,4 +104,3 @@ jobs:
           tag_name: ${{ steps.resolve_tag.outputs.tag }}
           name: ${{ steps.resolve_tag.outputs.tag }}
           generate_release_notes: true
-          update_existing: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -89,11 +89,20 @@ jobs:
             printf 'body=\n' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (CHANGELOG notes)
+        if: steps.notes.outputs.body != ''
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
         with:
           tag_name: ${{ steps.resolve_tag.outputs.tag }}
           name: ${{ steps.resolve_tag.outputs.tag }}
           body: ${{ steps.notes.outputs.body }}
-          generate_release_notes: ${{ steps.notes.outputs.body == '' }}
+          update_existing: true
+
+      - name: Create GitHub Release (auto-generated notes)
+        if: steps.notes.outputs.body == ''
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
+        with:
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          name: ${{ steps.resolve_tag.outputs.tag }}
+          generate_release_notes: true
           update_existing: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -36,7 +36,7 @@ jobs:
           tag="${tag//$'\n'/}"
           tag="${tag//$'\r'/}"
           if ! printf '%s' "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?$'; then
-            echo "::error::release_tag '${tag}' is not a valid semver (expected X.Y.Z or X.Y.Z-rcN)"
+            echo "::error::release_tag '${tag}' is not a valid semver (expected X.Y.Z, X.Y.Z-rcN, or X.Y.Z-rc.N)"
             exit 1
           fi
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
@@ -61,7 +61,7 @@ jobs:
             body=$(awk -v ver="$escaped" '
               /^## / {
                 if (found) exit
-                if (match($0, "— v?" ver "([[:space:]]|$)")) found = 1
+                if (match($0, "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] — v?" ver "([[:space:]]|$)")) found = 1
                 next
               }
               found { lines[++n] = $0 }

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -35,8 +35,8 @@ jobs:
           tag="${INPUT_TAG}"
           tag="${tag//$'\n'/}"
           tag="${tag//$'\r'/}"
-          if ! printf '%s' "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::release_tag '${tag}' is not a valid semver (expected X.Y.Z)"
+          if ! printf '%s' "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?$'; then
+            echo "::error::release_tag '${tag}' is not a valid semver (expected X.Y.Z or X.Y.Z-rcN)"
             exit 1
           fi
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -25,17 +25,33 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve tag
+        id: resolve_tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG}"
+          tag="${tag//$'\n'/}"
+          tag="${tag//$'\r'/}"
+          if ! printf '%s' "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::release_tag '${tag}' is not a valid semver (expected X.Y.Z)"
+            exit 1
+          fi
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ inputs.release_tag }}
+          ref: ${{ steps.resolve_tag.outputs.tag }}
 
       - name: Extract CHANGELOG notes
         id: notes
         shell: bash
         env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ steps.resolve_tag.outputs.tag }}
         run: |
           set -euo pipefail
           body=""
@@ -57,7 +73,8 @@ jobs:
                     last = i
                   }
                 }
-                for (i = first; i <= last; i++) print lines[i]
+                if (first > 0)
+                  for (i = first; i <= last; i++) print lines[i]
               }
             ' CHANGELOG.md)
           fi
@@ -75,8 +92,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
         with:
-          tag_name: ${{ inputs.release_tag }}
-          name: ${{ inputs.release_tag }}
+          tag_name: ${{ steps.resolve_tag.outputs.tag }}
+          name: ${{ steps.resolve_tag.outputs.tag }}
           body: ${{ steps.notes.outputs.body }}
           generate_release_notes: ${{ steps.notes.outputs.body == '' }}
           update_existing: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,82 @@
+name: create-github-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Version tag to release (e.g. 0.12.1)"
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Version tag to release (e.g. 0.12.1)"
+        type: string
+        required: true
+
+permissions:
+  contents: write
+
+# Opt into Node.js 24 early — Node 20 actions deprecated (removed Sep 2026)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.release_tag }}
+
+      - name: Extract CHANGELOG notes
+        id: notes
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          body=""
+          if [[ -f CHANGELOG.md ]]; then
+            # Escape dots for awk regex so "0.12.1" matches literally, not "0X12Y1"
+            escaped=$(printf '%s' "$RELEASE_TAG" | sed 's/[.]/\\./g')
+            body=$(awk -v ver="$escaped" '
+              /^## / {
+                if (found) exit
+                if (match($0, "— v?" ver "([[:space:]]|$)")) found = 1
+                next
+              }
+              found { lines[++n] = $0 }
+              END {
+                first = 0; last = 0
+                for (i = 1; i <= n; i++) {
+                  if (lines[i] ~ /[^[:space:]]/) {
+                    if (!first) first = i
+                    last = i
+                  }
+                }
+                for (i = first; i <= last; i++) print lines[i]
+              }
+            ' CHANGELOG.md)
+          fi
+          if [[ -n "$body" ]]; then
+            {
+              printf 'body<<__CHANGELOG_EOF__\n'
+              printf '%s\n' "$body"
+              printf '__CHANGELOG_EOF__\n'
+            } >> "$GITHUB_OUTPUT"
+          else
+            # No CHANGELOG section found; fall back to GitHub auto-generated notes
+            printf 'body=\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          name: ${{ inputs.release_tag }}
+          body: ${{ steps.notes.outputs.body }}
+          generate_release_notes: ${{ steps.notes.outputs.body == '' }}
+          update_existing: true

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ jobs:
     uses: nikolareljin/ci-helpers/.github/workflows/release-tag-gate.yml@production
 ```
 
-Auto-tag workflow:
+Auto-tag workflow (tag only):
 
 ```yaml
 name: Auto Tag Release
@@ -387,7 +387,55 @@ permissions:
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      update_production_tag: false
 ```
+
+Auto-tag + auto-create GitHub Release (recommended):
+
+1. Add a local wrapper at `.github/workflows/create-github-release.yml`:
+
+```yaml
+name: create-github-release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Version tag to release (e.g. 1.2.3)"
+        type: string
+        required: true
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
+    with:
+      release_tag: ${{ inputs.release_tag }}
+```
+
+2. Pass `release_workflow` in the auto-tag caller:
+
+```yaml
+name: Auto Tag Release
+on:
+  push:
+    branches: [ main, master ]
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: write
+
+jobs:
+  tag:
+    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      update_production_tag: false
+      release_workflow: create-github-release.yml
+```
+
+After each `release/X.Y.Z` merge the tag is created and a GitHub Release is published automatically. Release notes come from a matching `## DATE — VERSION` section in `CHANGELOG.md`, falling back to GitHub auto-generated notes.
+
 - Update vendored `script-helpers` with:
   - `./scripts/sync_script_helpers.sh`
   - Optional overrides: `SCRIPT_HELPERS_REPO_URL=...` and `SCRIPT_HELPERS_REF=...`

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ jobs:
       release_workflow: create-github-release.yml
 ```
 
-After each `release/X.Y.Z` merge the tag is created and a GitHub Release is published automatically. Release notes come from a matching `## DATE — VERSION` section in `CHANGELOG.md`, falling back to GitHub auto-generated notes.
+After each `release/X.Y.Z` (or `release/vX.Y.Z`, `release/X.Y.Z-rc1`) merge the tag is created and a GitHub Release is published automatically. Release notes come from a matching `## DATE — VERSION` section in `CHANGELOG.md`, falling back to GitHub auto-generated notes.
 
 - Update vendored `script-helpers` with:
   - `./scripts/sync_script_helpers.sh`

--- a/README.md
+++ b/README.md
@@ -430,8 +430,8 @@ jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
     with:
-      update_production_tag: false
       release_workflow: create-github-release.yml
+      # update_production_tag: false  # set this if your repo does not use a floating production tag
 ```
 
 After each `release/X.Y.Z` (or `release/vX.Y.Z`, `release/X.Y.Z-rc1`) merge the tag is created and a GitHub Release is published automatically. Release notes come from a matching `## DATE — VERSION` section in `CHANGELOG.md`, falling back to GitHub auto-generated notes.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -843,8 +843,10 @@ Inputs:
 - `runner` (string, default `ubuntu-latest`)
 - `fetch_depth` (number, default `0`)
 - `default_branch` (string, default `""`, uses repo default)
+- `update_production_tag` (boolean, default `true`) — when `false`, skips the Bootstrap script-helpers and Update production tag steps. Set to `false` in repos that do not carry a floating `production` tag.
+- `release_workflow` (string, default `""`) — filename of a local `workflow_dispatch` workflow to trigger after the version tag is pushed (e.g. `"create-github-release.yml"`). The workflow is dispatched with `release_tag` set to the detected version, using `gh workflow run --ref <tag>`. Requires `actions: write` on the caller. Leave empty to skip auto-dispatch.
 
-Example:
+Example (tag only, no production tag, no GitHub Release):
 
 ```yaml
 name: Auto Tag Release
@@ -859,7 +861,101 @@ permissions:
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      update_production_tag: false
 ```
+
+Example (tag + auto-create GitHub Release via dispatch):
+
+```yaml
+name: Auto Tag Release
+on:
+  push:
+    branches: [ main, master ]
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: write
+
+jobs:
+  tag:
+    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      update_production_tag: false
+      release_workflow: create-github-release.yml
+```
+
+See `create-github-release.yml` below for the local wrapper workflow that must exist in the calling repo.
+
+## create-github-release.yml
+
+Workflow: `.github/workflows/create-github-release.yml`
+
+Purpose: Create a GitHub Release for a version tag. Extracts release notes from `CHANGELOG.md` when a matching `## DATE — VERSION` section exists; falls back to GitHub auto-generated release notes otherwise. Supports `update_existing: true` so the workflow is safe to re-run.
+
+Triggers:
+- `workflow_dispatch` with `release_tag` input — used by the `release_workflow` dispatch mechanism in `auto-tag-release.yml`.
+- `workflow_call` with `release_tag` input — for direct use from other workflows.
+
+Inputs:
+- `release_tag` (string, required) — version tag to release (e.g. `1.2.3`).
+
+**Using in external repos**
+
+Create a thin local wrapper at `.github/workflows/create-github-release.yml` in your repo:
+
+```yaml
+name: create-github-release
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Version tag to release (e.g. 1.2.3)"
+        type: string
+        required: true
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
+    with:
+      release_tag: ${{ inputs.release_tag }}
+```
+
+Then wire your auto-tag caller to dispatch it:
+
+```yaml
+# .github/workflows/auto-tag-release-push.yml
+permissions:
+  contents: write
+  pull-requests: read
+  actions: write
+jobs:
+  tag:
+    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      update_production_tag: false
+      release_workflow: create-github-release.yml
+```
+
+The local wrapper is required because `gh workflow run` dispatches workflows in the current repo, not in ci-helpers. Repos that push tags via a PAT (not `GITHUB_TOKEN`) can use `on: push: tags:` and call `workflow_call` directly instead.
+
+**CHANGELOG format**
+
+Notes are extracted from `CHANGELOG.md` when a line matches `## <date> — <version>`:
+
+```markdown
+## 2026-06-12 — 1.2.3
+
+### Added
+- New feature X
+
+### Fixed
+- Bug in Y
+```
+
+Any other format, or no `CHANGELOG.md`, triggers GitHub auto-generated release notes.
 
 ## release-tag-gate.yml
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -892,7 +892,7 @@ See `create-github-release.yml` below for the local wrapper workflow that must e
 
 Workflow: `.github/workflows/create-github-release.yml`
 
-Purpose: Create a GitHub Release for a version tag. Extracts release notes from `CHANGELOG.md` when a matching `## DATE — VERSION` section exists; falls back to GitHub auto-generated release notes otherwise. Supports `update_existing: true` so the workflow is safe to re-run.
+Purpose: Create a GitHub Release for a version tag. Extracts release notes from `CHANGELOG.md` when a matching `## DATE — VERSION` section exists; falls back to GitHub auto-generated release notes otherwise. Re-runs are safe: `softprops/action-gh-release` updates an existing release when the `tag_name` already has one.
 
 Triggers:
 - `workflow_dispatch` with `release_tag` input — used by the `release_workflow` dispatch mechanism in `auto-tag-release.yml`.


### PR DESCRIPTION
## Summary

- **New** `create-github-release.yml` reusable workflow: accepts `release_tag` via `workflow_dispatch` (dispatched by the existing `auto-tag-release.yml` dispatch job) and `workflow_call` (for optional reuse in other repos). Checks out the tagged commit, extracts the matching CHANGELOG section, and creates/updates the GitHub Release via `softprops/action-gh-release@v3` (SHA-pinned). Falls back to GitHub auto-generated release notes when no CHANGELOG section exists.
- **Updated** `auto-tag-release-push.yml`: passes `release_workflow: create-github-release.yml` so ci-helpers automatically creates a GitHub Release after each version tag push going forward.

## Motivation

GitHub Releases stopped being created after `0.10.3` — tags `0.10.4` through `0.12.1` have no associated release. This wires up the `release_workflow` dispatch mechanism added in `0.12.1` to close that gap permanently.

## How it works

```
merge release/X.Y.Z → main
  └─ auto-tag-release-push.yml
       └─ auto-tag-release.yml
            ├─ tag job: push X.Y.Z tag + update production
            └─ dispatch job: gh workflow run create-github-release.yml \
                               --ref X.Y.Z -f release_tag=X.Y.Z
                  └─ create-github-release.yml
                       ├─ checkout at tag
                       ├─ extract CHANGELOG section for X.Y.Z
                       └─ softprops/action-gh-release → creates GitHub Release
```

## Optional use in other repos

```yaml
# In a caller workflow (e.g. after your own tag push):
jobs:
  release:
    uses: nikolareljin/ci-helpers/.github/workflows/create-github-release.yml@production
    with:
      release_tag: "1.2.3"
    permissions:
      contents: write
```

Falls back to GitHub auto-generated notes if no CHANGELOG.md or no matching section.

## Test plan

- [ ] Merge this PR; verify `auto-tag-release-push.yml` runs on the merge commit
- [ ] Next release cycle: merge a `release/X.Y.Z` branch; confirm GitHub Release is created with CHANGELOG notes
- [ ] Manually dispatch `create-github-release.yml` with `release_tag: 0.12.1` to backfill the latest missing release