### PR TITLE
fix(fpc-release): Windows PATH, AppImage retry, overwrite_files; bump pnpm/dorny actions

### DIFF
--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -212,7 +212,18 @@ jobs:
         env:
           FPC_PKG: ${{ inputs.fpc_choco_package }}
         shell: pwsh
-        run: choco install "$env:FPC_PKG" -y --no-progress
+        run: |
+          choco install "$env:FPC_PKG" -y --no-progress
+          # Chocolatey updates the Windows PATH but bash steps don't inherit it.
+          # Find fpc.exe and add its directory to GITHUB_PATH for subsequent steps.
+          $fpcExe = Get-ChildItem 'C:\fpc' -Recurse -Filter 'fpc.exe' -ErrorAction SilentlyContinue |
+                     Select-Object -First 1
+          if ($fpcExe) {
+            $fpcExe.DirectoryName | Add-Content -Path $env:GITHUB_PATH
+          } else {
+            Write-Error 'fpc.exe not found under C:\fpc after install'
+            exit 1
+          }
 
       - name: Build
         shell: bash
@@ -468,7 +479,7 @@ jobs:
                       ;;
                   esac
                 fi
-                wget -q --timeout=60 -- "${APPIMAGETOOL_URL}" -O /tmp/appimagetool
+                wget -q --timeout=60 --tries=3 --waitretry=5 -- "${APPIMAGETOOL_URL}" -O /tmp/appimagetool
                 actual_sha="$(sha256sum /tmp/appimagetool | awk '{print $1}')"
                 if [ -n "${APPIMAGETOOL_SHA256:-}" ]; then
                   if [ "$actual_sha" != "${APPIMAGETOOL_SHA256}" ]; then
@@ -626,7 +637,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/${{ steps.asset.outputs.asset }}
-          update_existing: true
+          overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -636,7 +647,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/dist_extra/*
-          update_existing: true
+          overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -646,6 +657,6 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/dist/${{ inputs.bin_name }}-${{ steps.tag.outputs.tag }}-${{ matrix.label }}.dmg
-          update_existing: true
+          overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pnpm-cypress.yml
+++ b/.github/workflows/pnpm-cypress.yml
@@ -67,7 +67,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
 
@@ -167,7 +167,7 @@ jobs:
 
       - name: Publish test results
         continue-on-error: true
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: ${{ format('Tests{0}', inputs.artifact_suffix) }}
           path: "test-results/**/*.xml"

--- a/.github/workflows/pnpm-playwright.yml
+++ b/.github/workflows/pnpm-playwright.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
 
@@ -156,7 +156,7 @@ jobs:
 
       - name: Publish test results
         continue-on-error: true
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: ${{ format('Tests{0}', inputs.artifact_suffix) }}
           path: "test-results/**/*.xml"

--- a/.github/workflows/pnpm-scan.yml
+++ b/.github/workflows/pnpm-scan.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
 

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ inputs.pnpm_version }}
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: Publish test results
         continue-on-error: true
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: ${{ format('Tests{0}', inputs.artifact_suffix) }}
           path: "test-results/**/*.xml"


### PR DESCRIPTION
## Summary

### fpc-release.yml fixes

- **Windows PATH**: After `choco install freepascal`, bash steps can't find `fpc` because Chocolatey updates the Windows environment but the bash shell doesn't inherit it. Fix: scan `C:\fpc` for `fpc.exe` and write its directory to `GITHUB_PATH` so subsequent bash steps pick it up.
- **AppImage wget retry**: `wget` to download `appimagetool` was failing with exit code 4 (network failure) on CI runners. Added `--tries=3 --waitretry=5` to make the download more resilient to transient failures.
- **`update_existing` → `overwrite_files`**: `softprops/action-gh-release` renamed this input; the old name was silently ignored, meaning duplicate uploads would fail. Replaced in all three upload steps.

### Dependabot action bumps

- `pnpm/action-setup`: v4 → v6 (pnpm.yml, pnpm-cypress.yml, pnpm-scan.yml, pnpm-playwright.yml)
- `dorny/test-reporter`: v2 → v3 (pnpm.yml, pnpm-cypress.yml, pnpm-playwright.yml)

## Test plan

- [ ] Re-run PravKal `release.yml` via `workflow_dispatch` for tag `0.2.1` after this merges to production
- [ ] Verify Windows runner finds `fpc` and builds `pravkal.exe` successfully
- [ ] Verify Linux runner downloads `appimagetool` and produces the `.AppImage`
- [ ] Verify all three GitHub release uploads succeed without `update_existing` warning