### PR TITLE
fix: bump aquasecurity/trivy-action SHA to 2026-06-15 master

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: Run Trivy
-      uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # master @ 2026-06-04
+      uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
       with:
         scan-type: fs
         scan-ref: ${{ inputs.scan_path }}

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Trivy scan (post-push)
         if: ${{ inputs.scan_after_build }}
-        uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # master @ 2026-06-04
+        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
         with:
           image-ref: ${{ steps.tags.outputs.primary }}
           format: table

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -56,7 +56,7 @@ jobs:
           docker build -f "${{ inputs.dockerfile }}" -t "${{ inputs.image_name }}" "${{ inputs.context }}"
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # master @ 2026-06-04
+        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
         with:
           image-ref: ${{ inputs.image_name }}
           format: table

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # master @ 2026-06-04
+        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
         with:
           scan-type: fs
           scan-ref: ${{ inputs.scan_path }}


### PR DESCRIPTION
## Summary
- Bumps `aquasecurity/trivy-action` SHA from `bfa4b33a` (2026-06-04) to `476e4fdc` (2026-06-15) in all 4 locations
- Detected by the `security-weekly` SHA Pin Audit job (run 27572366123)

## Files changed
- `.github/actions/trivy-scan/action.yml`
- `.github/workflows/docker-scan.yml`
- `.github/workflows/docker-multiarch.yml`
- `.github/workflows/trivy-scan.yml`