### PR TITLE
fix(fpc-release): generate fpc.cfg on Windows; build Intel macOS via macos-15-intel

### DIFF
--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -278,8 +278,12 @@ jobs:
             $mkcfgCmd = Get-Command fpcmkcfg -ErrorAction SilentlyContinue
             $mkcfgPath = if ($mkcfgCmd) { $mkcfgCmd.Path } else { $null }
           }
-          if ($mkcfgPath -and (Test-Path $mkcfgPath) -and $fpcDirFound) {
-            $cfgPath = Join-Path $fpcDir 'fpc.cfg'
+          $cfgPath = Join-Path $fpcDir 'fpc.cfg'
+          if (Test-Path $cfgPath) {
+            # A caller using a different package (or a preinstalled FPC) may ship
+            # a customized fpc.cfg. Don't overwrite it; only generate when absent.
+            Write-Output "fpc.cfg already present at $cfgPath; leaving it untouched."
+          } elseif ($mkcfgPath -and (Test-Path $mkcfgPath) -and $fpcDirFound) {
             & $mkcfgPath -d "basepath=$p" -o "$cfgPath"
             if ($LASTEXITCODE -eq 0 -and (Test-Path $cfgPath)) {
               Write-Output "Generated fpc.cfg at $cfgPath (basepath=$p)"

--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -136,9 +136,11 @@ jobs:
           - os: macos-latest
             label: macos-arm64
             binary_suffix: ""
-          - os: macos-13
-            label: macos-x86_64
-            binary_suffix: ""
+          # macos-13 (Intel) intentionally omitted: the hosted runner pool
+          # routinely fails to schedule it, leaving the job queued until the
+          # 24h job timeout and failing the whole release. Apple-Silicon
+          # (macos-latest/arm64) covers macOS; Intel Macs can run it via
+          # Rosetta or the linux build. Re-add if dedicated runners exist.
           - os: windows-latest
             label: windows-x86_64
             binary_suffix: .exe
@@ -256,6 +258,23 @@ jobs:
           }
           if (-not $fpcDirFound) {
             Write-Warning "lib\fpc not found within 5 directory levels of $fpcDir — FPCDIR not set; compilation may fail to locate RTL units."
+          }
+          # The Chocolatey freepascal package ships no fpc.cfg, so the driver
+          # has no RTL unit search paths and aborts with "Can't find unit crt"
+          # (or system, sysutils, …) even with FPCDIR set. Generate a default
+          # fpc.cfg from the install tree so ppcXXX can resolve RTL units.
+          # Placed next to fpc.exe, which is the first location the driver reads.
+          $mkcfg = Get-Command fpcmkcfg -ErrorAction SilentlyContinue
+          if ($mkcfg -and $fpcDirFound) {
+            $cfgPath = Join-Path $fpcDir 'fpc.cfg'
+            & $mkcfg.Source -d "basepath=$p" -o "$cfgPath"
+            if ($LASTEXITCODE -eq 0 -and (Test-Path $cfgPath)) {
+              Write-Output "Generated fpc.cfg at $cfgPath (basepath=$p)"
+            } else {
+              Write-Warning "fpcmkcfg exited $LASTEXITCODE; fpc.cfg may be missing — RTL unit resolution could fail."
+            }
+          } else {
+            Write-Warning "fpcmkcfg not found or FPCDIR unresolved; fpc.cfg not generated — RTL unit resolution may fail."
           }
 
       - name: Build

--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -136,11 +136,14 @@ jobs:
           - os: macos-latest
             label: macos-arm64
             binary_suffix: ""
-          # macos-13 (Intel) intentionally omitted: the hosted runner pool
-          # routinely fails to schedule it, leaving the job queued until the
-          # 24h job timeout and failing the whole release. Apple-Silicon
-          # (macos-latest/arm64) covers macOS; Intel Macs can run it via
-          # Rosetta or the linux build. Re-add if dedicated runners exist.
+          # Intel macOS uses macos-15-intel, the current schedulable hosted
+          # label. The retired macos-13 was dropped because its runner pool
+          # routinely failed to schedule, leaving the job queued until the 24h
+          # timeout and failing the whole release. macos-15-intel keeps the
+          # documented macos-x86_64 asset (see docs/workflows.md) building.
+          - os: macos-15-intel
+            label: macos-x86_64
+            binary_suffix: ""
           - os: windows-latest
             label: windows-x86_64
             binary_suffix: .exe
@@ -264,10 +267,20 @@ jobs:
           # (or system, sysutils, …) even with FPCDIR set. Generate a default
           # fpc.cfg from the install tree so ppcXXX can resolve RTL units.
           # Placed next to fpc.exe, which is the first location the driver reads.
-          $mkcfg = Get-Command fpcmkcfg -ErrorAction SilentlyContinue
-          if ($mkcfg -and $fpcDirFound) {
+          # Resolve fpcmkcfg.exe from $fpcDir first: when fpc.exe was located by
+          # the fallback scan (not Get-Command fpc), $fpcDir was only appended to
+          # GITHUB_PATH for later steps and is absent from this process's PATH,
+          # so Get-Command fpcmkcfg would miss the adjacent tool. Fall back to a
+          # PATH lookup and use the full .Path (not .Source, which can be empty
+          # for external executables) so we never invoke an empty command.
+          $mkcfgPath = Join-Path $fpcDir 'fpcmkcfg.exe'
+          if (-not (Test-Path $mkcfgPath)) {
+            $mkcfgCmd = Get-Command fpcmkcfg -ErrorAction SilentlyContinue
+            $mkcfgPath = if ($mkcfgCmd) { $mkcfgCmd.Path } else { $null }
+          }
+          if ($mkcfgPath -and (Test-Path $mkcfgPath) -and $fpcDirFound) {
             $cfgPath = Join-Path $fpcDir 'fpc.cfg'
-            & $mkcfg.Source -d "basepath=$p" -o "$cfgPath"
+            & $mkcfgPath -d "basepath=$p" -o "$cfgPath"
             if ($LASTEXITCODE -eq 0 -and (Test-Path $cfgPath)) {
               Write-Output "Generated fpc.cfg at $cfgPath (basepath=$p)"
             } else {


### PR DESCRIPTION
## Problem

Consumers of `fpc-release.yml` (e.g. PravKal) have **never produced Windows or Intel-macOS release assets**; every release run fails:

1. **Windows** — `bash build.sh` aborts with:
   ```
   pravkal.pas(4,6) Fatal: Can't find unit crt used by pravkal
   ppc386.exe returned an error exitcode
   ```
   The Chocolatey `freepascal` package ships **no `fpc.cfg`**, so the `fpc` driver has no RTL unit search paths — even though we set `FPCDIR`. The driver needs `fpc.cfg` to add `-Fu$FPCDIR/units/$target/*`.

2. **Intel macOS (`macos-13`)** — the retired `macos-13` hosted runner pool routinely failed to schedule, so the job sat **queued until the 24h job timeout** and failed the whole release.

## Fix

- **Windows:** after resolving `FPCDIR`, generate a default `fpc.cfg` with `fpcmkcfg -d basepath=$FPCDIR -o <fpcDir>\fpc.cfg` (next to `fpc.exe`, the driver's first config location). `fpcmkcfg` is resolved from `$fpcDir` first (then a PATH fallback via the full `.Path`) so it is found even when `fpc.exe` came from the fallback scan. The config is generated **only when no `fpc.cfg` already exists**, so a customized config from a different package or preinstalled FPC is never overwritten. Guarded with warnings if `fpcmkcfg` is absent.
- **Intel macOS:** replace the unschedulable `macos-13` matrix entry with **`macos-15-intel`** (label `macos-x86_64`), the current schedulable GitHub-hosted Intel runner (supported through Aug 2027). This keeps the documented `macos-x86_64` release asset building instead of silently dropping it.

## Validation
- YAML parses cleanly; `fail-fast: false` retained.
- The Windows fix is reasoned from the failure log but **should be confirmed on a Windows runner** once merged.

## Notes
- **No tag move.** This PR targets `main` only. The `production` tag is unchanged — advancing it to ship this to consumers is left to the normal release flow / maintainer.
