### PR TITLE
fix(auto-tag-release): export version output via workflow_call.outputs

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -29,6 +29,14 @@ on:
           NOTE: callers must also grant actions: write permission.
         type: string
         default: ""
+    outputs:
+      version:
+        description: >
+          Release version detected from the merged release/X.Y.Z PR (empty when
+          the push was not a release/* merge). Exposed so callers can gate
+          follow-up jobs — e.g. creating the GitHub Release or moving a
+          production branch — on `needs.<job>.outputs.version`.
+        value: ${{ jobs.tag.outputs.version }}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem
The reusable `auto-tag-release.yml` defines a job-level output (`jobs.tag.outputs.version`) but never re-exports it under `on.workflow_call.outputs`. Job-level outputs are **not** visible to callers, so a caller reading `needs.<job>.outputs.version` always gets an empty string. Any caller job gated on it (e.g. creating the GitHub Release, moving a `production` branch) is silently skipped — the run only creates the tag.

This was surfaced by a P1 review on script-helpers#41, which consumes this workflow and relies on the version output.

## Fix
Add an `on.workflow_call.outputs.version` entry mapping to `jobs.tag.outputs.version`, so callers can consume the detected release version.

## Impact
Backward-compatible: adds an output, changes nothing for existing callers that don't read it. Consumed via the `production` branch, so it takes effect for downstream repos once merged and `production` is moved.

Not merging — yours to merge.