### PR TITLE
chore(security): refresh stale pinned action SHAs (unblock security-weekly)

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: Run Trivy
-      uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
+      uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6 # master @ 2026-06-22
       with:
         scan-type: fs
         scan-ref: ${{ inputs.scan_path }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Create GitHub Release (CHANGELOG notes)
         if: steps.notes.outputs.body != ''
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.resolve_tag.outputs.tag }}
           name: ${{ steps.resolve_tag.outputs.tag }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create GitHub Release (auto-generated notes)
         if: steps.notes.outputs.body == ''
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.resolve_tag.outputs.tag }}
           name: ${{ steps.resolve_tag.outputs.tag }}

--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload .deb to GitHub release
         if: inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.resolve.outputs.tag }}
           files: ${{ inputs.artifact_glob }}

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Trivy scan (post-push)
         if: ${{ inputs.scan_after_build }}
-        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
+        uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6 # master @ 2026-06-22
         with:
           image-ref: ${{ steps.tags.outputs.primary }}
           format: table

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -56,7 +56,7 @@ jobs:
           docker build -f "${{ inputs.dockerfile }}" -t "${{ inputs.image_name }}" "${{ inputs.context }}"
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
+        uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6 # master @ 2026-06-22
         with:
           image-ref: ${{ inputs.image_name }}
           format: table

--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -704,7 +704,7 @@ jobs:
 
       - name: Upload to GitHub release
         if: inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/${{ steps.asset.outputs.asset }}
@@ -714,7 +714,7 @@ jobs:
 
       - name: Upload extra Linux packages to GitHub release
         if: runner.os == 'Linux' && inputs.linux_packages != '' && inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/dist_extra/*
@@ -724,7 +724,7 @@ jobs:
 
       - name: Upload macOS DMG to GitHub release
         if: runner.os == 'macOS' && inputs.macos_dmg == 'true' && inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/dist/${{ inputs.bin_name }}-${{ steps.tag.outputs.tag }}-${{ matrix.label }}.dmg

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -239,7 +239,7 @@ jobs:
           write_multiline_output "notes" "$notes_content"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-24
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref }}
           release_name: ${{ inputs.release_name != '' && inputs.release_name || format('Release {0}', github.ref_name) }}

--- a/.github/workflows/rust-release-tarballs.yml
+++ b/.github/workflows/rust-release-tarballs.yml
@@ -150,7 +150,7 @@ jobs:
           echo "sha256=$sha256"   >> "$GITHUB_OUTPUT"
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ steps.package.outputs.tarball }}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -614,7 +614,7 @@ jobs:
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-05-23
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3 @ 2026-06-22
         with:
           tag_name: ${{ steps.rel.outputs.tag }}
           name: ${{ inputs.release_name != '' && inputs.release_name || format('Release {0}', steps.rel.outputs.tag) }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # master @ 2026-06-15
+        uses: aquasecurity/trivy-action@cf5c088a69634cd13ccddc735d7926162c31f9a6 # master @ 2026-06-22
         with:
           scan-type: fs
           scan-ref: ${{ inputs.scan_path }}


### PR DESCRIPTION
## What

Refreshes stale pinned action SHAs so the weekly **SHA Pin Audit** (`security-weekly` → `scripts/update_pinned_actions.sh --check`) passes again. That job fails on *any* stale pin (exit 1).

## Why it was failing

The last `security-weekly` run failed in **SHA Pin Audit** only (the other 5 jobs passed). `aquasecurity/trivy-action` and `softprops/action-gh-release` pins had fallen behind upstream. Because the pins track moving refs (`master` / `v3`), they drift stale over time and the weekly audit is the reminder to bump them.

## Changes (SHA + date-comment only, no logic)

Generated by running the repo's own `scripts/update_pinned_actions.sh`. The inline date-comment is the **bump date** the script stamps (`# <ref> @ <date>` = when the pin was refreshed, i.e. 2026-06-22), not the upstream commit date.

- `aquasecurity/trivy-action`: `476e4fdc` → **`cf5c088a`** (current `master` HEAD) — 3 workflows + `trivy-scan` composite action
- `softprops/action-gh-release`: `b4309332` → **`718ea10b`** (current `v3` HEAD) — create-github-release, deb-build, fpc-release (×3), go-release, rust-release-tarballs, tauri-release

## Verification

```
$ bash scripts/update_pinned_actions.sh --check
Summary: 46 up-to-date, 0 stale, 0 warnings.   # exit 0
```

`security-weekly` dispatched on this branch passed all 6 jobs (incl. SHA Pin Audit). After merge, the scheduled run on `main` will pass.
