### PR TITLE
fix(fpc-release): Windows build (units landmark) + publish bare .exe

### DIFF
--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -397,6 +397,9 @@ jobs:
             fi
           done
           (cd dist && powershell -Command "Compress-Archive -Path '${pkg}' -DestinationPath '${pkg}.zip'")
+          # Also publish the bare .exe alongside the zip: a clickable standalone
+          # binary for users who don't need the bundled data files.
+          cp -- "${BIN_NAME}${BIN_SUFFIX}" "dist/${pkg}.exe"
           printf 'asset=dist/%s.zip\n' "$pkg" >> "$GITHUB_OUTPUT"
 
       # ── Linux packaging: DEB / RPM / AppImage ─────────────────────────────
@@ -729,6 +732,16 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           files: ${{ inputs.working_directory }}/dist/${{ inputs.bin_name }}-${{ steps.tag.outputs.tag }}-${{ matrix.label }}.dmg
+          overwrite_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows EXE to GitHub release
+        if: runner.os == 'Windows' && inputs.upload_to_release != 'false' && steps.resolve.outputs.skip == 'false'
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3 @ 2026-04-12
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          files: ${{ inputs.working_directory }}/dist/${{ inputs.bin_name }}-${{ steps.tag.outputs.tag }}-${{ matrix.label }}.exe
           overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fpc-release.yml
+++ b/.github/workflows/fpc-release.yml
@@ -244,14 +244,15 @@ jobs:
           # Derive FPC installation root (FPCDIR) so the fpc driver can locate
           # RTL units. The Chocolatey freepascal package ships a ZIP without
           # fpc.cfg, so we cannot use that file as a landmark. Instead we walk
-          # up from fpc.exe's directory until we find lib\fpc, which is always
-          # present in the install tree regardless of whether fpc.cfg exists.
+          # up from fpc.exe's directory until we find the RTL units root.
+          # The Windows package keeps RTL under <root>\units\<target>, while a
+          # Unix-style tree keeps it under lib\fpc — accept either landmark.
           $p = $fpcDir
           $fpcDirFound = $false
-          for ($i = 0; $i -lt 5; $i++) {
-            if (Test-Path (Join-Path $p 'lib\fpc')) {
+          for ($i = 0; $i -lt 6; $i++) {
+            if ((Test-Path (Join-Path $p 'units')) -or (Test-Path (Join-Path $p 'lib\fpc'))) {
               "FPCDIR=$p" | Add-Content -Path $env:GITHUB_ENV
-              Write-Output "Set FPCDIR=$p (found lib\fpc at depth $i)"
+              Write-Output "Set FPCDIR=$p (RTL landmark found at depth $i)"
               $fpcDirFound = $true
               break
             }
@@ -260,7 +261,7 @@ jobs:
             $p = $parent
           }
           if (-not $fpcDirFound) {
-            Write-Warning "lib\fpc not found within 5 directory levels of $fpcDir — FPCDIR not set; compilation may fail to locate RTL units."
+            Write-Warning "No FPC RTL landmark (units or lib\fpc) within 6 directory levels of $fpcDir — FPCDIR not set; compilation may fail to locate RTL units."
           }
           # The Chocolatey freepascal package ships no fpc.cfg, so the driver
           # has no RTL unit search paths and aborts with "Can't find unit crt"


### PR DESCRIPTION
## Problem

PravKal (and other consumers) have never produced working Windows assets:

1. **Build fails** — `bash build.sh` aborts with `Can't find unit crt`. The FPCDIR walk looked for a Unix-style `lib\fpc` landmark; the Chocolatey `freepascal` package installs RTL units under `<root>\units\<target>`, so FPCDIR was never resolved and `fpc.cfg` generation (guarded on it) was skipped.
2. **No bare .exe** — the Windows job only emits a `.zip` (exe + data).

## Fixes

- **Build:** accept a `units` directory as the FPCDIR landmark (in addition to `lib\fpc`), widen the walk to 6 levels. FPCDIR now resolves on the Windows package and `fpcmkcfg` generates a working `fpc.cfg` → `crt` resolves.
- **Packaging:** also copy the raw `pravkal.exe` to `dist/<pkg>.exe` and upload it as a separate release asset, so consumers get **both** a clickable standalone `.exe` and the `.zip` data bundle.

## Validation
- YAML parses; reasoned from the failing PravKal release log. Should be confirmed green on the next Windows release run.

## Rollout
- **No tag move here.** Targets `main`. Consumers pin `@production`, so this only reaches them after `production` is advanced via `scripts/create_production.sh` (maintainer's release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)