### PR TITLE
chore(security): bump securego/gosec SHA pin (unblock security-weekly)

### DIFF
--- a/.github/workflows/go-scan.yml
+++ b/.github/workflows/go-scan.yml
@@ -56,6 +56,6 @@ jobs:
 
       - name: Gosec scan
         if: ${{ inputs.gosec_args != '' }}
-        uses: securego/gosec@6a008f60b8f7f3d7fae8f126984a9df5d4b7e0cf # master @ 2026-06-22
+        uses: securego/gosec@f88a0781159d73052ba792962e624749904783d6 # master @ 2026-06-25
         with:
           args: ${{ inputs.gosec_args }}


### PR DESCRIPTION
## What

Bumps the pinned `securego/gosec` SHA in `go-scan.yml`:

- `6a008f6` (master @ 2026-06-22) → `f88a078` (master @ 2026-06-25, current master HEAD)

## Why

`gosec` is pinned to a floating `master`. The weekly `security-weekly` SHA-pin audit (`update_pinned_actions.sh --check`) fails as soon as upstream master advances past the pinned commit — which it has. Latest scheduled run on `main` failed with `1 stale` for exactly this pin. Same recurring drift previously unblocked by #77 and #101.

## Verification

```
$ bash scripts/update_pinned_actions.sh --check
Summary: 47 up-to-date, 0 stale, 0 warnings.   # exit 0
```

Single-line pin bump; no behavior change.