### PR TITLE
release: 0.21.2

### DIFF
--- a/.github/workflows/homebrew-package.yml
+++ b/.github/workflows/homebrew-package.yml
@@ -181,7 +181,7 @@ jobs:
             args+=(--exclude "$ex")
           done
 
-          ./vendor/script-helpers/scripts/build_brew_tarball.sh "${args[@]}"
+          bash ./vendor/script-helpers/scripts/build_brew_tarball.sh "${args[@]}"
 
       - name: Generate Homebrew formula
         shell: bash

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -92,7 +92,7 @@ jobs:
             prebuild_args=(--prebuild "$prebuild")
           fi
 
-          ./vendor/script-helpers/scripts/build_rpm_artifacts.sh \
+          bash ./vendor/script-helpers/scripts/build_rpm_artifacts.sh \
             --repo "$repo" \
             "${spec_args[@]}" \
             "${prebuild_args[@]}" \


### PR DESCRIPTION
Patch release 0.21.2.\n\nFixes Distrodeck's RPM and Homebrew packaging jobs failing with exit 126 when script-helpers packaging scripts are checked out without executable bits. The reusable workflows now invoke those scripts explicitly through Bash.\n\nAfter merge, the release tag flow will advance the shared production tag and branch through scripts/create_production.sh.